### PR TITLE
Pre-release v0.1.0-B1912003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.1.0-B1912003 (pre-release)
+
 - Fixed `Kubernetes.AKS.PublicLB` handling of internal LB annotation. [#17](https://github.com/BernieWhite/PSRule.Rules.Kubernetes/issues/17)
 - Updated metadata rule to align to recommended labels. [#14](https://github.com/BernieWhite/PSRule.Rules.Kubernetes/issues/14)
 - Expanded deployment rules to include pods and replica sets. [#13](https://github.com/BernieWhite/PSRule.Rules.Kubernetes/issues/13)


### PR DESCRIPTION
## PR Summary

- Fixed `Kubernetes.AKS.PublicLB` handling of internal LB annotation. #17
- Updated metadata rule to align to recommended labels. #14
- Expanded deployment rules to include pods and replica sets. #13
- Added rule documentation. #5
- Added new rule `Kubernetes.API.Removal` to check for use of removed APIs. #18
- Added new rule `Kubernetes.Pod.Secrets` to check if sensitive environment variables are used. #19
- Added new rule `Kubernetes.Pod.Health` to check health probes are used. #20
- Added new rule `Kubernetes.Pod.Replicas` to check if more then one replica is used. #21
- **Breaking change**: Renamed deployment rules to relate to pods. #12


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
