### PR TITLE
Pre-release v0.1.0-B2001007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.1.0-B2001007 (pre-release)
+
 - **Breaking change**: Updated and renamed baselines make them easier to use. [#27](https://github.com/BernieWhite/PSRule.Rules.Kubernetes/issues/27)
   - `KubeBaseline` is now `Kubernetes`, the default baseline.
   - `AKSBaseline` is now `AKS`.


### PR DESCRIPTION
## PR Summary

- **Breaking change**: Updated and renamed baselines make them easier to use. #27
  - `KubeBaseline` is now `Kubernetes`, the default baseline.
  - `AKSBaseline` is now `AKS`.
  - The `Kubernetes` baseline include common Kubernetes rules.
  - The `AKS` baseline include all of `Kubernetes` plus additional AKS specific rules.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
